### PR TITLE
Configuration review

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -10,18 +10,21 @@ omero.web:
 # Information about the session store.
 session-store:
     #type is either "postgres" or "redis"
-    type: "postgres"
+    type: "redis"
     #synchronicity is either "sync" or "async"
     synchronicity: "async"
     #uri for either postgres db or redis
     # * https://jdbc.postgresql.org/documentation/80/connect.html
     # * https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details
-    uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # For Redis in protected mode
+    uri: "redis://:@localhost:6379/1"
+    # For Redis in non-protected mode
     # uri: "redis://:password@localhost:6379/1"
 
  # Configuration for zipkin http tracing
 http-tracing:
-    enabled: true
+    enabled: false
     zipkin-url: "http://localhost:9411/api/v2/spans"
 
 # Enable JMX Prometheus Metrics

--- a/src/dist/conf/logback.xml
+++ b/src/dist/conf/logback.xml
@@ -8,9 +8,11 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${application.home:-.}/logs/omero-ms.log</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log</fileNamePattern>
-      </rollingPolicy>
+            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+    </rollingPolicy>
     <encoder>
       <pattern>%date [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
@@ -21,6 +23,6 @@
   <logger name="loci.formats.Memoizer" level="INFO"/><!-- Bio-Formats memoizer -->
 
   <root level="info">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
   </root>
 </configuration>


### PR DESCRIPTION
Rebased from https://github.com/glencoesoftware/omero-ms-thumbnail/pull/22 following the branch unification

- set redis as the default backend for sessions
- disable http-tracing by default
- add default logback configuration to rotate, zip, add timestamp and keep 7 days of logs