### PR TITLE
Review micro-service systemd service file

### DIFF
--- a/src/dist/omero-ms-thumbnail.service
+++ b/src/dist/omero-ms-thumbnail.service
@@ -5,9 +5,9 @@ After=network.service
 
 [Service]
 Type=simple
-#Environment="JAVA_OPTS=-Dlogback.configurationFile=/path/to/omero-ms-thumbnail/logback.xml"
-WorkingDirectory=/path/to/omero-ms-thumbnail
-ExecStart=/path/to/omero-ms-thumbnail/bin/omero-ms-thumbnail
+Environment="JAVA_OPTS=-Dlogback.configurationFile=/opt/omero/OMERO.ms/omero-ms-thumbnail/current/conf/logback.xml"
+WorkingDirectory=/opt/omero/OMERO.ms/omero-ms-thumbnail/current
+ExecStart=/opt/omero/OMERO.ms/omero-ms-thumbnail/current/bin/omero-ms-thumbnail
 User=omero
 Group=omero
 Restart=no


### PR DESCRIPTION
Point at standard micro-service location by default

Similar to #23 , this should ensure the file shipped with the micro-service can be used without modifications in most cases