### PR TITLE
Bump omero-ms-core version to 0.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
-    implementation 'com.glencoesoftware.omero:omero-ms-core:0.6.1'
+    implementation 'com.glencoesoftware.omero:omero-ms-core:0.7.0'
     implementation 'io.vertx:vertx-web:3.8.1'
     implementation 'io.vertx:vertx-config:3.8.1'
     implementation 'io.vertx:vertx-config-yaml:3.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'io.vertx:vertx-web:3.8.1'
     implementation 'io.vertx:vertx-config:3.8.1'
     implementation 'io.vertx:vertx-config-yaml:3.8.1'
-    implementation 'org.openmicroscopy:omero-blitz:5.5.12'
+    implementation 'org.openmicroscopy:omero-blitz:5.6.2'
     implementation 'io.prometheus.jmx:collector:0.12.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.8.0'
     implementation 'com.zeroc:icegrid:3.6.5'


### PR DESCRIPTION
Primarily propagates the pickle fix from https://github.com/glencoesoftware/omero-ms-core/pull/27

Also includes a bump of `omero-blitz` to the latest version - see https://github.com/ome/omero-blitz/blob/v5.6.2/CHANGELOG.md

Proposing for an `0.5.7`  release