### PR TITLE
Startup script: use wildcard for the classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,3 +103,7 @@ distributions {
 applicationDefaultJvmArgs = [
   "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
 ]
+
+startScripts {
+  classpath = files('$APP_HOME/lib/*')
+}


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-ms-image-region/pull/146

This pattern improves the extensibility of the micro-service as extension JARs can easily be added to lib/ folder and will be included at restart without the requirement to modify the CLASSPATH in the executable