### PR TITLE
Upload Java 11 artifacts as release assets on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,18 @@ jobs:
         with:
           name: omero-ms-thumbnail ${{ matrix.java }}
           path: build/distributions/*
+  release:
+    if: startsWith(github.ref, 'refs/tags')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v4
+        with:
+          name: omero-ms-thumbnail 11
+      - name: List artifacts
+        run: ls -R
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: omero-ms-thumbnail-*


### PR DESCRIPTION
Follow-up of #30, this re-use the strategy used in other repositories to upload the build artifacts as release assets on tags

As a proof of concept see https://github.com/sbesson/omero-ms-thumbnail/releases/tag/v0.5.10-rc1 created from a tag at  2d5c7f5c8a38b5e8f2a6a2a218225c3f69ff5a69