### PR TITLE
Bump io.lettuce:lettuce-core from 5.2.0.RELEASE to 6.7.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
+    implementation 'io.lettuce:lettuce-core:6.7.1.RELEASE'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.9.1'
     implementation 'io.vertx:vertx-web:3.8.1'
     implementation 'io.vertx:vertx-config:3.8.1'

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -15,12 +15,12 @@ session-store:
     synchronicity: "async"
     #uri for either postgres db or redis
     # * https://jdbc.postgresql.org/documentation/80/connect.html
-    # * https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details
+    # * https://redis.github.io/lettuce/user-guide/connecting-redis/
     # uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
     # For Redis in protected mode
     uri: "redis://:@localhost:6379/1"
     # For Redis in non-protected mode
-    # uri: "redis://:password@localhost:6379/1"
+    # uri: "redis://username:password@localhost:6379/1"
 
  # Configuration for zipkin http tracing
 http-tracing:


### PR DESCRIPTION
See also https://github.com/glencoesoftware/omero-ms-core/pull/40. 

See https://redis.github.io/lettuce/new-features/ for a list of the changes associated with the last major and minor version increments In addition to a long overdue maintenance routine, the primary motivation for this change is to have support for ACL authentication introduced in Redis 6.x and available since the 6.0.0.RELEASE of lettuce-core

eea667c6c3183927ab70422d3bf384e9049cd308 overrides `lettuce-core` coming from `omero-ms-core` and the GitHub actions should produce an omero-ms-thumbnail artifact for testing. Ultimately this dependency should be upgraded and released in `omero-ms-core`. 

Functionally, the micro-service should be tested with and without this PR against various Redis 6+ configurations:
- [Protected mode](https://redis.io/docs/latest/operate/oss_and_stack/management/security/#protected-mode) i.e. Redis only responding to queries from the loopback interface `"redis://:@localhost:6379/1"`
- [Authentiction via requirepass](https://redis.io/docs/latest/operate/oss_and_stack/management/security/#authentication): `"redis://:<password>@localhost:6379/1"`
- [Authentication via ACL](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/) using the default user: `"redis://default:<password>@localhost:6379/1"`
- [Authentication via ACL](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/) using a non default user: `"redis://<username>:<password>@localhost:6379/1"`

My expectation is that wit the current version of the library, the last scenario is not supported and the third one is unclear - the `default` username might be ignored by the library. With the library upgrade, the thumbnails should be served by the micro-services under all configurations.