### PR TITLE
Set java.io.tmpdir to local application directory at startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,9 +108,13 @@ distributions {
 }
 
 applicationDefaultJvmArgs = [
-  "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
+  "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory",
+  "-Djava.io.tmpdir=MY_APP_HOME/tmp"
 ]
 
 startScripts {
   classpath = files('$APP_HOME/lib/*')
+  doLast {
+    unixScript.text = unixScript.text.replace("MY_APP_HOME", "'\$APP_HOME'")
+  }
 }


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-ms-image-region/pull/163 and https://github.com/glencoesoftware/omero-ms-pixel-buffer/pull/31 for similar changes in other micro-services

To test these changes

- download a new version of `omero-ms-thumbnail` with this change included from GitHub actions or build it locally
- start  `omero-ms-thumbnail` either manually of via `systemd`
  * check a `tmp` subfolder has been created under the application home at startup
  * check `$APP_HOME/tmp` contains a `vertx-cache-*` folder related to the micro-service initialisation
- stop the application
  * observe that the folders under `$APP_HOME/tmp` are deleted