### PR TITLE
Update release step of GitHub workflow to use gh CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         java: [8, 11, 17, 21]
@@ -27,17 +29,20 @@ jobs:
           name: omero-ms-thumbnail ${{ matrix.java }}
           path: build/distributions/*
   release:
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags')
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Download artifacts from build
         uses: actions/download-artifact@v4
         with:
           name: omero-ms-thumbnail 11
       - name: List artifacts
         run: ls -R
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: omero-ms-thumbnail-*
+      - name: Create a GitHub release
+        run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}" omero-ms-thumbnail-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Inspired by the work in https://github.com/ome/ome-common-java/pull/107, this makes use of the `gh` CLI available in the GitHub runners with the default `GITHUB_TOKEN` and the appropriate permissions to create a GitHub release including generated notes and assets instead of a third-party action

