### PR TITLE
Make EventBus Timeout Configurable

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -1,5 +1,8 @@
 # The port that the microservice will listen on
 port: 8080
+# EventBus Send Timeout in ms - default in microservice is 15000
+# see http://vertx.io/docs/apidocs/constant-values.html#io.vertx.core.eventbus.DeliveryOptions.DEFAULT_TIMEOUT
+event-bus-send-timeout: 15000
 # OMERO server that the microservice will communicate with (as a client)
 omero:
     host: localhost

--- a/src/main/java/com/glencoesoftware/omero/ms/thumbnail/ThumbnailMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/thumbnail/ThumbnailMicroserviceVerticle.java
@@ -48,6 +48,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.ThreadingModel;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.http.HttpServer;
@@ -92,6 +93,9 @@ public class ThumbnailMicroserviceVerticle extends AbstractVerticle {
 
     /** VerticleFactory */
     private OmeroVerticleFactory verticleFactory;
+
+    /** DeliveryOptions (including event bus send timeout) */
+    private DeliveryOptions deliveryOptions;
 
     /** Default number of workers to be assigned to the worker verticle */
     private int DEFAULT_WORKER_POOL_SIZE;
@@ -212,6 +216,11 @@ public class ThumbnailMicroserviceVerticle extends AbstractVerticle {
 
         httpTracing = HttpTracing.newBuilder(tracing).build();
         log.info("Deploying verticle");
+
+        deliveryOptions = new DeliveryOptions()
+                .setSendTimeout(Optional.ofNullable(
+                        config.getInteger("event-bus-send-timeout")
+                        ).orElse(15000));
 
         JsonObject jmxMetricsConfig =
                 config.getJsonObject("jmx-metrics", new JsonObject());
@@ -402,7 +411,7 @@ public class ThumbnailMicroserviceVerticle extends AbstractVerticle {
         thumbnailCtx.injectCurrentTraceContext();
         vertx.eventBus().<byte[]>request(
                 ThumbnailVerticle.RENDER_THUMBNAIL_EVENT,
-                Json.encode(thumbnailCtx), result -> {
+                Json.encode(thumbnailCtx), deliveryOptions, result -> {
             try {
                 if (handleResultFailed(result, response)) {
                     return;
@@ -451,7 +460,7 @@ public class ThumbnailMicroserviceVerticle extends AbstractVerticle {
 
         vertx.eventBus().<String>request(
                 ThumbnailVerticle.GET_THUMBNAILS_EVENT,
-                Json.encode(thumbnailCtx), result -> {
+                Json.encode(thumbnailCtx), deliveryOptions, result -> {
             try {
                 if (handleResultFailed(result, response)) {
                     return;


### PR DESCRIPTION
Fixes #37 
See github.com/glencoesoftware/omero-ms-image-region/pull/160

This PR is mostly for consistency with omero-ms-image-region in allowing the configuration of the EventBus send timeout in the `config.yml` file. 

## Testing
This one is trickier to test. The only ways I've succeeded are:
1. Add a `sleep` line in the code
2. Import a test image like `'test&sizeX=2304&sizeY=2304&sizeZ=12&sizeC=3&pixelType=uint16&sleepOpenBytes=500.fake'`. Note the image ID. Then the very first call to `webclient/render_birds_eye_view/<image id>/96` will trigger the sleep. Set your config accordingly to induce the timeout.