### PR TITLE
Bump omero-ms-core to 0.12.0 and omero-blitz to 5.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
-    implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
+    implementation 'com.glencoesoftware.omero:omero-ms-core:0.12.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'
     implementation 'io.vertx:vertx-config-yaml:4.5.16'

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'
     implementation 'io.vertx:vertx-config-yaml:4.5.16'
-    implementation 'org.openmicroscopy:omero-blitz:5.8.3'
+    implementation 'org.openmicroscopy:omero-blitz:5.8.4'
     implementation 'io.prometheus.jmx:collector:0.12.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.8.0'
     implementation 'com.zeroc:icegrid:3.6.5'


### PR DESCRIPTION
See https://github.com/ome/omero-blitz/releases/tag/v5.8.4 and https://github.com/glencoesoftware/omero-ms-core/releases/tag/v0.12.0

This is mostly a routine dependency upgrade to make sure the latest versions of the libraries are available in the next release of the micro-service